### PR TITLE
Add simulation arguments (IUS) for simulation phase

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -452,7 +452,6 @@ class Ius(Simulator):
                 + self.get_define_commands(self.defines)
                 + self.get_include_commands(self.includes)
                 + self.compile_args
-                + self.simulation_args
                 + self.verilog_sources
                 + self.vhdl_sources
             )
@@ -462,7 +461,7 @@ class Ius(Simulator):
             self.logger.warning("Skipping compilation:" + out_file)
 
         if not self.compile_only:
-            cmd_run = ["irun", "-64", "-R", ("-gui" if self.gui else "")]
+            cmd_run = ["irun", "-64", "-R", ("-gui" if self.gui else "")] + self.simulation_args
             cmd.append(cmd_run)
 
         return cmd


### PR DESCRIPTION
This pull request will add simulation arguments for simulation phase in Cadence IUS simulator. This is important, because some arguments are only valid in simulation phase, for example  "-covtest" that can generate unique name for every code coverage database. 