### PR TITLE
Fix double run when using the arg `simulator`

### DIFF
--- a/cocotb_test/run.py
+++ b/cocotb_test/run.py
@@ -7,5 +7,5 @@ def run(simulator=None, **kwargs):
     if simulator:
         sim = simulator(**kwargs)
         sim.run()
-
-    cocotb_test.simulator.run(**kwargs)
+    else:
+        cocotb_test.simulator.run(**kwargs)


### PR DESCRIPTION
When calling `cocotb_test.run()` with `simulator != None`, the test is run twice because of a missing `else` clause.