### PR TITLE
added sim.log in /sim_build directory

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -214,27 +214,30 @@ class Simulator(object):
 
         return paths_abs
 
+    def escape_ansi(self, line):
+        ansi_escape = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]")
+        return ansi_escape.sub("", line)
+
     def execute(self, cmds):
         self.set_env()
         for cmd in cmds:
             self.logger.info("Running command: " + " ".join(cmd))
 
-            self.process = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=self.work_dir, env=self.env
-            )
+            with subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                cwd=self.work_dir,
+                env=self.env,
+                bufsize=1,
+            ) as p, open(self.work_dir + "/simlog.log", "w") as file:
+                for line in p.stdout:
+                    sys.stdout.buffer.write(line)
+                    escaped_line = self.escape_ansi(line.decode("utf-8"))
+                    file.write(escaped_line)
 
-            while True:
-                out = self.process.stdout.readline()
-
-                if not out and self.process.poll() is not None:
-                    break
-
-                log_out = out.decode("utf-8").rstrip()
-                if log_out != "":
-                    self.logger.info(log_out)
-
-            if self.process.returncode:
-                self.logger.error("Command terminated with error %d" % self.process.returncode)
+            if p.returncode:
+                self.logger.error("Command terminated with error %d" % p.returncode)
                 return
 
     # def execute(self, cmds):


### PR DESCRIPTION
Everything showing up in the terminal when running a simulation isn't part of any log files when using cocotb-test.
This includes all the log messages from cocotb, such as:
self.dut._log.info("Doing something")

The following changes to the Simulator class enable that: sim.log is created in the /sim_build directory.
