### PR TITLE
Fix error when starting test in thread

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -7,6 +7,7 @@ import cocotb
 import logging
 import shutil
 from xml.etree import cElementTree as ET
+import threading
 import signal
 
 from distutils.spawn import find_executable
@@ -140,9 +141,11 @@ class Simulator(object):
         # Catch SIGINT and SIGTERM
         self.old_sigint_h = signal.getsignal(signal.SIGINT)
         self.old_sigterm_h = signal.getsignal(signal.SIGTERM)
-
-        signal.signal(signal.SIGINT, self.exit_gracefully)
-        signal.signal(signal.SIGTERM, self.exit_gracefully)
+        
+        # works only if main thread
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, self.exit_gracefully)
+            signal.signal(signal.SIGTERM, self.exit_gracefully)
 
     def set_env(self):
 


### PR DESCRIPTION
Error:

```
/usr/local/lib/python3.6/dist-packages/cocotb_test/simulator.py:807: in run
    sim = Ghdl(**kwargs)
/usr/local/lib/python3.6/dist-packages/cocotb_test/simulator.py:144: in __init__
    signal.signal(signal.SIGINT, self.exit_gracefully)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

signalnum = <Signals.SIGINT: 2>, handler = <bound method Simulator.exit_gracefully of <cocotb_test.simulator.Ghdl object at 0x7f27edecb2b0>>

    @_wraps(_signal.signal)
    def signal(signalnum, handler):
>       handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
E       ValueError: signal only works in main thread

/usr/lib/python3.6/signal.py:47: ValueError
```

