### PR TITLE
Verilator plusargs

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -782,7 +782,7 @@ class Verilator(Simulator):
         cmd.append(["make", "-C", self.sim_dir, "-f", "Vtop.mk"])
 
         if not self.compile_only:
-            cmd.append([out_file])
+            cmd.append([out_file] + self.plus_args)
 
         return cmd
 


### PR DESCRIPTION
Add `plus_args` to Verilator binary execution. This enables adding _plusargs_ such as `+verilator+rand+reset+2` to Verilator.