### PR TITLE
Verilator: C++ flag -std=c++11 should only be set for C++ files (CXXFLAGS)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get install git make autoconf g++ flex bison   # First time prerequisites
           sudo apt-get install libfl2  # Ubuntu only (ignore if gives error)
           sudo apt-get install libfl-dev  # Ubuntu only (ignore if gives error)
-          git clone http://git.veripool.org/git/verilator --depth=1
+          git clone http://git.veripool.org/git/verilator -b v4.106 --depth=1
           cd verilator && autoconf && ./configure && make -j2 && sudo make install && cd ..
         displayName: Compile and Install Verilator on Linux
         condition: and( eq( variables['Agent.OS'], 'Linux' ), eq(variables['SIM'], 'verilator'))

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -839,7 +839,7 @@ class Verilator(Simulator):
         if self.vhdl_sources:
             raise ValueError("This simulator does not support VHDL")
 
-        self.env['CPPFLAGS'] =  self.env.get('CPPFLAGS', "") + " -std=c++11"
+        self.env['CXXFLAGS'] =  self.env.get('CXXFLAGS', "") + " -std=c++11"
 
     def get_include_commands(self, includes):
         include_cmd = []


### PR DESCRIPTION
`CPPFLAGS` is the flags for C/C++ pre-processor. It is appended to `CFLAGS` in many build systems (including python distutils). `-std=c++11` is obviously not a valid flag for the C-compiler. `clang` will refuse to compile any `C` files when this flag is present. `-std=c++11` should instead be only added to C++ compilation flags (`CXXFLAGS`)