### PR TITLE
Ghdl: support waves argument

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -727,7 +727,7 @@ class Ghdl(Simulator):
 
         cmd = []
 
-        out_file = os.path.join(self.sim_dir, self.toplevel + ".o")
+        out_file = os.path.join(self.sim_dir, self.toplevel)
 
         if self.outdated(out_file, self.verilog_sources + self.vhdl_sources) or self.force_compile:
             for source_file in self.vhdl_sources:

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -736,6 +736,9 @@ class Ghdl(Simulator):
             cmd_elaborate = ["ghdl", "-m"] + self.compile_args + [self.toplevel]
             cmd.append(cmd_elaborate)
 
+        if self.waves:
+            self.simulation_args.append("--wave=" + self.toplevel + ".ghw")
+
         cmd_run = [
             "ghdl",
             "-r",


### PR DESCRIPTION
This PR implements trivial support for the `waves` argument for ghdl.

Furthermore, a small bug is fixed: The executable name doesn't have an extension. Previously this could lead to strange behaviour. I. e. when an object file (".o") is generated, but there is an error when compiling the executable.