### PR TITLE
cocotb_test/simulator.py: fix exit gracefully

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -167,11 +167,13 @@ class Simulator(object):
         # Catch SIGINT and SIGTERM
         self.old_sigint_h = signal.getsignal(signal.SIGINT)
         self.old_sigterm_h = signal.getsignal(signal.SIGTERM)
-        
+
         # works only if main thread
         if threading.current_thread() is threading.main_thread():
             signal.signal(signal.SIGINT, self.exit_gracefully)
             signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+        self.process = None
 
     def set_env(self):
 
@@ -260,9 +262,11 @@ class Simulator(object):
                 cwd=self.work_dir,
                 env=self.env
             ) as p:
+                self.process = p
                 for line in p.stdout:
                     self.logger.info(line.decode("utf-8").rstrip())
 
+            self.process = None
             if p.returncode:
                 self.logger.error("Command terminated with error %d" % p.returncode)
                 return


### PR DESCRIPTION
Hi,
This small fix avoids the exception during the call to `exit_gracefully()` and prevents the simulator to keep running in the background after sensing a SIGINT.

```
================================================================================================================= FAILURES =================================================================================================================
_____________________________________________________________________________________________________________ test_axi_device ______________________________________________________________________________________________________________

self = <nmigen_cocotb.Icarus_g2005 object at 0x7ff14b667100>
cmds = [['iverilog', '-o', '/tmp/tmphv4tc1qb/top.vvp', '-D', 'COCOTB_SIM=1', '-s', ...], ['vvp', '-M', 'xxx...sim-model/test_venv/lib/python3.9/site-packages/cocotb/libs', '-m', 'libcocotbvpi_icarus', '/tmp/tmphv4tc1qb/top.vvp']]

    def execute(self, cmds):
        self.set_env()
        for cmd in cmds:
            self.logger.info("Running command: " + " ".join(cmd))
    
            with subprocess.Popen(
                cmd,
                stdout=subprocess.PIPE,
                stderr=subprocess.STDOUT,
                cwd=self.work_dir,
                env=self.env
            ) as p:
>               for line in p.stdout:

test_venv/lib/python3.9/site-packages/cocotb_test/simulator.py:263: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <nmigen_cocotb.Icarus_g2005 object at 0x7ff14b667100>, signum = 2
frame = <frame at 0x7ff14b7879f0, file 'xxx...sim-model/test_venv/lib/python3.9/site-packages/cocotb_test/simulator.py', line 264, code execute>

    def exit_gracefully(self, signum, frame):
        pid = None
>       if self.process is not None:
E       AttributeError: 'Icarus_g2005' object has no attribute 'process'

test_venv/lib/python3.9/site-packages/cocotb_test/simulator.py:296: AttributeError
```