### PR TITLE
Add compile arguments to the GHDL run/simulate command

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -743,12 +743,12 @@ class Ghdl(Simulator):
         if self.waves:
             self.simulation_args.append("--wave=" + self.toplevel + ".ghw")
 
-        cmd_run = [
-            "ghdl",
-            "-r",
-            self.toplevel,
-            "--vpi=" + cocotb.config.lib_name_path("vpi", "ghdl"),
-        ] + self.simulation_args + self.get_parameter_commands(self.parameters)
+        cmd_run = (
+            ["ghdl", "-r"] + self.compile_args + [self.toplevel]
+            + ["--vpi=" + cocotb.config.lib_name_path("vpi", "ghdl")]
+            + self.simulation_args
+            + self.get_parameter_commands(self.parameters)
+        )
 
         if not self.compile_only:
             cmd.append(cmd_run)


### PR DESCRIPTION
Hello!

GHDL run/simulate command also takes the compile/elaboration arguments but before the top level name. For reference: https://ghdl.readthedocs.io/en/latest/using/InvokingGHDL.html#run-r

I had a problem where `ghdl -r` wouldn't find the entity when compiling with `compile_args=['--std=08']`