### PR TITLE
Add named library support for Questa simulator

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -23,7 +23,6 @@ _space_re = re.compile(r"([\s])", re.ASCII)
 
 def as_tcl_value(value):
     # add '\' before special characters and spaces
-    print(value)
     value = _magic_re.sub(r"\\\1", value)
     value = value.replace("\n", r"\n")
     value = _space_re.sub(r"\\\1", value)
@@ -477,7 +476,6 @@ class Questa(Simulator):
                 self.toplevel_lib = self.toplevel
 
             for library, sources in self.verilog_sources.items():
-                print(f"{library}: {sources}")
                 do_script = "vlib {RTL_LIBRARY}; vlog -mixedsvvh {FORCE} -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES};".format(
                     RTL_LIBRARY=as_tcl_value(library),
                     VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in sources),

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -329,20 +329,6 @@ class Simulator(object):
         if self.verilog_sources is not None:
             assert isinstance(self.verilog_sources, list), "Parameter `verilog_sources` must be a list of strings."
 
-    def format_sources_as_dict(self):
-        """Format sources as dict for simulators that support named libraries."""
-        if self.vhdl_sources:
-            if type(self.vhdl_sources) == list:
-                # format `self.vhdl_sources` as dict with default library
-                self.toplevel_lib = self.toplevel
-                self.vhdl_sources = {f"{self.toplevel_lib}": self.vhdl_sources}
-
-        if self.verilog_sources:
-            if isinstance(self.verilog_sources, list):
-                # format `self.verilog_sources` as dict with default library
-                self.verilog_sources = {f"{self.toplevel}": self.verilog_sources}
-                self.toplevel_lib = self.toplevel
-
 
 class Icarus(Simulator):
     def __init__(self, *argv, **kwargs):
@@ -464,9 +450,11 @@ class Questa(Simulator):
 
         cmd = []
 
-        self.format_sources_as_dict()
-
         if self.vhdl_sources:
+            if type(self.vhdl_sources) == list:
+                self.toplevel_lib = self.toplevel
+                self.vhdl_sources = {f"{self.toplevel_lib}": self.vhdl_sources}
+
             do_script = ""
             for library, sources in self.vhdl_sources.items():
                 do_script += "vlib {RTL_LIBRARY}; vcom -mixedsvvh {FORCE} -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES};".format(
@@ -831,38 +819,32 @@ class Riviera(Simulator):
 
         out_file = os.path.join(self.sim_dir, self.rtl_library, self.rtl_library + ".lib")
 
-        self.format_sources_as_dict()
-
         if self.outdated(out_file, self.verilog_sources + self.vhdl_sources) or self.force_compile:
 
-            if self.vhdl_sources:
+            do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(self.rtl_library))
 
-                for library, sources in self.vhdl_sources.items():
-                    do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(library))
-                    do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
-                        RTL_LIBRARY=as_tcl_value(library),
-                        VHDL_SOURCES=" ".join(as_tcl_value(v) for v in sources),
-                        EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
-                    )
+            if self.vhdl_sources:
+                do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
+                    RTL_LIBRARY=as_tcl_value(self.rtl_library),
+                    VHDL_SOURCES=" ".join(as_tcl_value(v) for v in self.vhdl_sources),
+                    EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
+                )
 
             if self.verilog_sources:
-
-                for library, sources in self.verilog_sources.items():
-                    do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(library))
-                    do_script += "alog -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
-                        RTL_LIBRARY=as_tcl_value(library),
-                        VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in sources),
-                        DEFINES=" ".join(self.get_define_commands(self.defines)),
-                        INCDIR=" ".join(self.get_include_commands(self.includes)),
-                        EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
-                    )
+                do_script += "alog -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
+                    RTL_LIBRARY=as_tcl_value(self.rtl_library),
+                    VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in self.verilog_sources),
+                    DEFINES=" ".join(self.get_define_commands(self.defines)),
+                    INCDIR=" ".join(self.get_include_commands(self.includes)),
+                    EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
+                )
         else:
             self.logger.warning("Skipping compilation:" + out_file)
 
         if not self.compile_only:
             if self.toplevel_lang == "vhdl":
                 do_script += "asim +access +w -interceptcoutput -O2 -loadvhpi {EXT_NAME} {EXTRA_ARGS} {RTL_LIBRARY}.{TOPLEVEL} \n".format(
-                    RTL_LIBRARY=as_tcl_value(self.toplevel_lib),
+                    RTL_LIBRARY=as_tcl_value(self.rtl_library),
                     TOPLEVEL=as_tcl_value(self.toplevel),
                     EXT_NAME=as_tcl_value(cocotb.config.lib_name_path("vhpi", "riviera")),
                     EXTRA_ARGS=" ".join(as_tcl_value(v) for v in (self.simulation_args + self.get_parameter_commands(self.parameters))),
@@ -871,7 +853,7 @@ class Riviera(Simulator):
                     self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vpi", "riviera") + "cocotbvpi_entry_point"
             else:
                 do_script += "asim +access +w -interceptcoutput -O2 -pli {EXT_NAME} {EXTRA_ARGS} {RTL_LIBRARY}.{TOPLEVEL} {PLUS_ARGS} \n".format(
-                    RTL_LIBRARY=as_tcl_value(self.toplevel_lib),
+                    RTL_LIBRARY=as_tcl_value(self.rtl_library),
                     TOPLEVEL=as_tcl_value(self.toplevel),
                     EXT_NAME=as_tcl_value(cocotb.config.lib_name_path("vpi", "riviera")),
                     EXTRA_ARGS=" ".join(as_tcl_value(v) for v in (self.simulation_args + self.get_parameter_commands(self.parameters))),
@@ -920,31 +902,25 @@ class Activehdl(Simulator):
 
         out_file = os.path.join(self.sim_dir, self.rtl_library, self.rtl_library + ".lib")
 
-        self.format_sources_as_dict()
-
         if self.outdated(out_file, self.verilog_sources + self.vhdl_sources) or self.force_compile:
 
-            if self.vhdl_sources:
+            do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(self.rtl_library))
 
-                for library, sources in self.vhdl_sources.items():
-                    do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(library))
-                    do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
-                        RTL_LIBRARY=as_tcl_value(library),
-                        VHDL_SOURCES=" ".join(as_tcl_value(v) for v in sources),
-                        EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
-                    )
+            if self.vhdl_sources:
+                do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
+                    RTL_LIBRARY=as_tcl_value(self.rtl_library),
+                    VHDL_SOURCES=" ".join(as_tcl_value(v) for v in self.vhdl_sources),
+                    EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
+                )
 
             if self.verilog_sources:
-
-                for library, sources in self.verilog_sources.items():
-                    do_script += "alib {RTL_LIBRARY} \n".format(RTL_LIBRARY=as_tcl_value(self.rtl_library))
-                    do_script += "alog {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
-                        RTL_LIBRARY=as_tcl_value(library),
-                        VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in sources),
-                        DEFINES=" ".join(self.get_define_commands(self.defines)),
-                        INCDIR=" ".join(self.get_include_commands(self.includes)),
-                        EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
-                    )
+                do_script += "alog {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
+                    RTL_LIBRARY=as_tcl_value(self.rtl_library),
+                    VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in self.verilog_sources),
+                    DEFINES=" ".join(self.get_define_commands(self.defines)),
+                    INCDIR=" ".join(self.get_include_commands(self.includes)),
+                    EXTRA_ARGS=" ".join(as_tcl_value(v) for v in self.compile_args),
+                )
         else:
             self.logger.warning("Skipping compilation:" + out_file)
 
@@ -955,8 +931,9 @@ class Activehdl(Simulator):
         do_script = ""
 
         if self.toplevel_lang == "vhdl":
-            do_script += "set worklib " + as_tcl_value(self.toplevel_lib) + "\n"
+            do_script += "set worklib " + as_tcl_value(self.rtl_library) + "\n"
             do_script += "asim +access +w -interceptcoutput -O2 -loadvhpi \"{EXT_NAME}\" {EXTRA_ARGS} {TOPLEVEL} \n".format(
+                RTL_LIBRARY=as_tcl_value(self.rtl_library),
                 TOPLEVEL=as_tcl_value(self.toplevel),
                 EXT_NAME=as_tcl_value(cocotb.config.lib_name_path("vhpi", "activehdl") + ":vhpi_startup_routines_bootstrap"),
                 EXTRA_ARGS=" ".join(self.simulation_args + self.get_parameter_commands(self.parameters)),
@@ -965,7 +942,7 @@ class Activehdl(Simulator):
                 self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vpi", "activehdl") + "cocotbvpi_entry_point"
         else:
             do_script += "asim +access +w -interceptcoutput -O2 -pli \"{EXT_NAME}\" {EXTRA_ARGS} {RTL_LIBRARY}.{TOPLEVEL} {PLUS_ARGS} \n".format(
-                RTL_LIBRARY=as_tcl_value(self.toplevel_lib),
+                RTL_LIBRARY=as_tcl_value(self.rtl_library),
                 TOPLEVEL=as_tcl_value(self.toplevel),
                 EXT_NAME=as_tcl_value(cocotb.config.lib_name_path("vpi", "activehdl")),
                 EXTRA_ARGS=" ".join(as_tcl_value(v) for v in (self.simulation_args + self.get_parameter_commands(self.parameters))),

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -480,8 +480,9 @@ class Questa(Simulator):
             cmd.append(["vsim"] + ["-c"] + ["-do"] + [do_script])
 
         if self.verilog_sources:
+            do_script = ""
             for library, sources in self.verilog_sources.items():
-                do_script = "vlib {RTL_LIBRARY}; vlog -mixedsvvh {FORCE} -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES};".format(
+                do_script += "vlib {RTL_LIBRARY}; vlog -mixedsvvh {FORCE} -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES};".format(
                     RTL_LIBRARY=as_tcl_value(library),
                     VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in sources),
                     DEFINES=" ".join(self.get_define_commands(self.defines)),

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     author="Tomasz Hemperek",
     author_email="hemperek@uni-bonn.de",
     packages=find_packages(),
+    python_requires=">=3.7",
     install_requires=["cocotb>=1.5", "pytest"],
     entry_points={
         "console_scripts": [

--- a/tests/dff_wrapper.vhdl
+++ b/tests/dff_wrapper.vhdl
@@ -1,0 +1,27 @@
+-- This file is public domain, it can be freely copied without restrictions.
+-- SPDX-License-Identifier: CC0-1.0
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library some_lib;
+use some_lib.dff_test_vhdl;
+
+entity dff_wrapper is
+port(
+  clk: in std_logic;
+  d: in std_logic;
+  q: out std_logic);
+end dff_wrapper;
+
+architecture behavioral of dff_wrapper is
+begin
+
+  dff_inst: entity some_lib.dff_test_vhdl
+  port map (
+    clk => clk,
+    d => d,
+    q => q
+  );
+
+end behavioral;

--- a/tests/test_dff_custom_lib.py
+++ b/tests/test_dff_custom_lib.py
@@ -1,17 +1,16 @@
-from typing import OrderedDict
+from collections import OrderedDict
 from cocotb_test.simulator import run
 import pytest
 import os
 
 tests_dir = os.path.dirname(__file__)
 
-@pytest.mark.skipif(os.getenv("SIM") == "verilator", reason="VHDL not suported")
-@pytest.mark.skipif(os.getenv("SIM") == "icarus", reason="VHDL not suported")
+@pytest.mark.skipif(os.getenv("SIM") != "questa", reason="Named libraries only supported for Questa simulator")
 def test_dff_vhdl():
     run(
         vhdl_sources = OrderedDict([
             ("some_lib", [os.path.join(tests_dir, "dff.vhdl")]),
-            ("some_other_lib", [os.path.join(tests_dir, "dff_wrapper.vhdl")])
+            ("some_other_lib", [os.path.join(tests_dir, "dff_wrapper.vhdl")]),
         ]),
         toplevel="dff_wrapper",
         module="dff_cocotb",

--- a/tests/test_dff_custom_lib.py
+++ b/tests/test_dff_custom_lib.py
@@ -11,10 +11,9 @@ def test_dff_vhdl():
             "some_lib": [os.path.join(tests_dir, "dff.vhdl")],
             "some_other_lib": [os.path.join(tests_dir, "dff_wrapper.vhdl")],
         },
-        toplevel="dff_wrapper",
+        toplevel="some_other_lib.dff_wrapper",
         module="dff_cocotb",
         toplevel_lang="vhdl",
-        toplevel_lib="some_other_lib",
         force_compile=True,
     )
 

--- a/tests/test_dff_custom_lib.py
+++ b/tests/test_dff_custom_lib.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from cocotb_test.simulator import run
 import pytest
 import os
@@ -8,10 +7,10 @@ tests_dir = os.path.dirname(__file__)
 @pytest.mark.skipif(os.getenv("SIM") != "questa", reason="Named libraries only supported for Questa simulator")
 def test_dff_vhdl():
     run(
-        vhdl_sources = OrderedDict([
-            ("some_lib", [os.path.join(tests_dir, "dff.vhdl")]),
-            ("some_other_lib", [os.path.join(tests_dir, "dff_wrapper.vhdl")]),
-        ]),
+        vhdl_sources = {
+            "some_lib": [os.path.join(tests_dir, "dff.vhdl")],
+            "some_other_lib": [os.path.join(tests_dir, "dff_wrapper.vhdl")],
+        },
         toplevel="dff_wrapper",
         module="dff_cocotb",
         toplevel_lang="vhdl",

--- a/tests/test_dff_custom_lib.py
+++ b/tests/test_dff_custom_lib.py
@@ -1,0 +1,25 @@
+from typing import OrderedDict
+from cocotb_test.simulator import run
+import pytest
+import os
+
+tests_dir = os.path.dirname(__file__)
+
+@pytest.mark.skipif(os.getenv("SIM") == "verilator", reason="VHDL not suported")
+@pytest.mark.skipif(os.getenv("SIM") == "icarus", reason="VHDL not suported")
+def test_dff_vhdl():
+    run(
+        vhdl_sources = OrderedDict([
+            ("some_lib", [os.path.join(tests_dir, "dff.vhdl")]),
+            ("some_other_lib", [os.path.join(tests_dir, "dff_wrapper.vhdl")])
+        ]),
+        toplevel="dff_wrapper",
+        module="dff_cocotb",
+        toplevel_lang="vhdl",
+        toplevel_lib="some_other_lib",
+        force_compile=True,
+    )
+
+
+if __name__ == "__main__":
+    test_dff_vhdl()


### PR DESCRIPTION
Implements #148, #135 for Questa simulator only (I only have Questa available in my environment), but this can easily be adapted for other simulators as well.

This changes how sources (now a dict) and toplevel (now requires a library identifier) are represented. To not require other Simulator implementations to be changed and for the user to be able to chose if they use this feature or not, I added the `format_input()` method which formats sources and toplevel parameter, depending on if the Simulator implementation supports the feature or not.

`tests/test_dff_custom_lib.py` showcases the interface.