### PR TITLE
add simulator override to simulator.run()

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -910,7 +910,7 @@ class Activehdl(Simulator):
 
         if self.waves:
             do_script += "log -recursive /*;"
-            
+
         return do_script
 
     def build_script_run(self):
@@ -1018,7 +1018,10 @@ class Verilator(Simulator):
 
 def run(**kwargs):
 
-    sim_env = os.getenv("SIM", "icarus")
+    if "simulator" in kwargs:
+        sim_env = kwargs["simulator"]
+    else:
+        sim_env = os.getenv("SIM", "icarus")
 
     supported_sim = ["icarus", "questa", "ius", "xcelium", "vcs", "ghdl", "riviera", "activehdl", "verilator"]
     if sim_env not in supported_sim:

--- a/tests/test_dff_simulator_override.py
+++ b/tests/test_dff_simulator_override.py
@@ -1,0 +1,20 @@
+from cocotb_test.simulator import run
+import pytest
+import os
+
+tests_dir = os.path.dirname(__file__)
+
+# This test only executes for GHDL. If `simulator` override does not work, it should fail.
+@pytest.mark.skipif(os.getenv("SIM") != "ghdl", reason="This test is supposed to fail.")
+def test_dff_verilog():
+    run(
+        verilog_sources=[os.path.join(tests_dir,"dff.v")],
+        toplevel="dff_test",
+        module="dff_cocotb",
+        simulator="icarus"
+    )
+
+
+if __name__ == "__main__":
+    test_dff_verilog()
+    #test_dff_vhdl()


### PR DESCRIPTION
Adds the possibility to override simulator when calling `simulator.run()`, as proposed in #125.

Alternatively the parameter could be named `simulator_override`, which makes it more apparent, that this will override the `SIM` env variable.