### PR TITLE
Add ability to specify simulator as argument to run method

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -1016,9 +1016,18 @@ class Verilator(Simulator):
         return cmd
 
 
-def run(**kwargs):
+def run(simulator=None, **kwargs):
 
-    sim_env = os.getenv("SIM", "icarus")
+    sim_env = os.getenv("SIM")
+
+    # priority, highest first, is: env, kwarg, "icarus"
+    if sim_env is None:
+        if simulator is None:
+            sim_env = "icarus"
+        else:
+            sim_env = simulator
+    elif simulator is not None:
+        warnings.warn(f"'SIM={sim_env}' overrides kwarg 'simulator={simulator}'")
 
     supported_sim = ["icarus", "questa", "ius", "xcelium", "vcs", "ghdl", "riviera", "activehdl", "verilator"]
     if sim_env not in supported_sim:

--- a/tests/test_simulator_kwarg.py
+++ b/tests/test_simulator_kwarg.py
@@ -1,0 +1,24 @@
+from cocotb_test.simulator import run
+import pytest
+import os
+
+tests_dir = os.path.dirname(__file__)
+
+# The regression test system currently runs all tests with SIM=(something valid)
+# It would be nice to include a test this with SIM unset in the automated regressions.
+
+# Check that SIM= environment variable takes priority over kwarg
+@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.xfail(os.getenv("SIM") is None,
+                   reason = "Bad simulator name should be used when SIM is unset",
+                   strict = True,
+                   raises = NotImplementedError)
+def test_env_takes_priority():
+    run(
+        verilog_sources=[
+            os.path.join(tests_dir, "dff.v"),
+        ],
+        toplevel="dff_test",
+        module="dff_cocotb",
+        simulator="bad_sim_name"
+    )


### PR DESCRIPTION
Add "simulator" kwarg to run() which can be used instead of SIM environment variable.
If both are set, SIM takes precedence and warns if they are different.
"icarus" is still the default if neither is set.

Add a test for SIM taking precedence over an invalid simulator kwarg.

This addresses #125 in a similar way to #163 but with some differences.

I opted to have the existing SIM environment variable take priority over the kwarg, printing a warning if they are different. It seemed like it might be useful to be able to override the choice of simulator on the command line... The priority could be switched the other way around if there is good reason.

`simulator` is deleted from `kwargs` before passing to simulator constructor, to suppress a warning.