### PR TITLE
Move simulation/run script generation to separate methods for `Questa`

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -517,6 +517,10 @@ class Questa(Simulator):
 
         return sim_script
 
+    def build_script_run(self):
+
+        return "run -all; quit"
+
     def build_command(self):
 
         cmd = []
@@ -560,7 +564,7 @@ class Questa(Simulator):
 
             do_script = self.build_script_sim()
             if not self.gui:
-                do_script += "run -all; quit"
+                do_script += self.build_script_run()
 
             cmd.append(["vsim"] + (["-gui"] if self.gui else ["-c"]) + ["-do"] + [do_script])
 

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -557,7 +557,7 @@ class Questa(Simulator):
         if not self.compile_only:
             if self.toplevel_lang == "vhdl":
                 if self.verilog_sources:
-                    self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vpi", "questa")+":cocotbvpi_entry_point"
+                    self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("vpi", "questa") + ":cocotbvpi_entry_point"
             else:
                 if self.vhdl_sources:
                     self.env["GPI_EXTRA"] = cocotb.config.lib_name_path("fli", "questa") + ":cocotbfli_entry_point"

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -495,6 +495,8 @@ class Questa(Simulator):
         do_script = ""
         if self.waves:
             do_script += "log -recursive /*;"
+        if not self.gui:
+            do_script += "run -all; quit"
         return do_script
 
     def build_command(self):
@@ -502,8 +504,6 @@ class Questa(Simulator):
         cmd = []
 
         do_script = self.do_script()
-        if not self.gui:
-            do_script += "run -all; quit"
 
         if self.vhdl_sources:
             compile_args = self.compile_args + self.vhdl_compile_args


### PR DESCRIPTION
This makes it easier to implement custom extension of `Questa` class, for example for use case #169.
