### PR TITLE
Add option to pass argument to verilator's make.  Useful to speed up …

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -59,6 +59,7 @@ class Simulator:
         waves=None,
         gui=False,
         simulation_args=None,
+        more_compile_args=None,
         **kwargs,
     ):
 
@@ -134,6 +135,11 @@ class Simulator:
             extra_args = []
 
         self.compile_args = compile_args + extra_args
+
+        if more_compile_args is None:
+            self.more_compile_args = []
+        else:
+            self.more_compile_args = more_compile_args
 
         if sim_args is None:
             sim_args = []
@@ -1103,7 +1109,7 @@ class Verilator(Simulator):
             + self.verilog_sources_flat
         )
 
-        cmd.append(["make", "-C", self.sim_dir, "-f", "Vtop.mk"])
+        cmd.append(["make", "-C", self.sim_dir, "-f", "Vtop.mk"] + self.more_compile_args)
 
         if not self.compile_only:
             cmd.append([out_file] + self.plus_args)


### PR DESCRIPTION
…compilation.

I'm running verilator on a large design and the compilation was taking a long time.  I wanted to able to call 'make -j 16' to speed things up, but there wasn't an option to pass arguments to verilator's make command.

I just called the argument 'more_compile_args' for lack of any better ideas, and in case some other simulator could also make use of it.

On a side note, if anyone has any suggestions for ways I can make verilator compilation less slow for large designs I'd love to hear them!