### PR TITLE
Fix fsdb dumping for vcs with +all

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -780,18 +780,17 @@ class Vcs(Simulator):
 
         compile_args = self.compile_args + self.verilog_compile_args
         if self.waves:
-            compile_args += ["-kdb", "-debug_access"]
+            compile_args += ["-kdb", "-debug_access+all"]
 
         simv_path = os.path.join(self.sim_dir, self.module)
         cmd_build = (
             [
                 "vcs",
                 "-full64",
-                "-debug",
+                "-sverilog",
                 "+vpi",
                 "-P",
                 "pli.tab",
-                "-sverilog",
                 "+define+COCOTB_SIM=1",
                 "-load",
                 cocotb.config.lib_name_path("vpi", "vcs"),
@@ -814,7 +813,7 @@ class Vcs(Simulator):
                 ucli_do = os.path.join(self.sim_dir, f"{self.module}_ucli.do")
                 with open(ucli_do, "w") as f:
                     f.write(f"fsdbDumpfile {simv_path}.fsdb; fsdbDumpvars 0 {self.toplevel_module}; run; quit;")
-                cmd_run += ["-ucli", "-do", ucli_do]
+                cmd_run += ["+fsdb+all=on", "-ucli", "-do", ucli_do]
             cmd.append(cmd_run)
 
         if self.gui:

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -779,8 +779,10 @@ class Vcs(Simulator):
             pli_file.write(pli_cmd)
 
         compile_args = self.compile_args + self.verilog_compile_args
+        debug_access = "-debug_access"
         if self.waves:
-            compile_args += ["-kdb", "-debug_access+all"]
+            debug_access += "+all+dmptf"
+            compile_args += ["-kdb", "-debug_region+cell"]
 
         simv_path = os.path.join(self.sim_dir, self.module)
         cmd_build = (
@@ -788,7 +790,7 @@ class Vcs(Simulator):
                 "vcs",
                 "-full64",
                 "-sverilog",
-                "+vpi",
+                debug_access,
                 "-P",
                 "pli.tab",
                 "+define+COCOTB_SIM=1",


### PR DESCRIPTION
This extends the work on #183. I realized after testing a little further that it wasn't dumping some variables that I wanted. It would cover basic things but, for example, wouldn't dump the values for any unpacked real arrays. I didn't know this at first but apparently you have to add `+fsdb+all=on` when you run the sim executable (typically called `simv` for vcs) to have it dump all types of variables and other more complicated system verilog constructs. Anyway, these changes will fix that. Below is a screenshot of it working.
![image](https://user-images.githubusercontent.com/21026563/172908747-0a25038a-24cc-46ac-9ef5-c1b421269da0.png)

Some other notes/changes as I was working through this:
- `-debug` compile arg is soon to be deprecated by Synopsys so I updated that to `-debug_access` (at least this is what my vcs 2020 tells me, it may in fact already be deprecated today)
- Using `-debug_access` no longer requires a separate `+vpi` flag as the vcs documentation says it's already automatically turned on when you specify `-debug_access`
- I leaned on the side of turning on as many debug features as possible when waveforms are enabled because typically when you want to look at waveforms you want to see everything that is going on. The downside is simulation runtime when waveforms are enabled but it will still run fast when waveforms are disabled because all those extra debug features will be turned off.