### PR TITLE
fix: pass LDFLAGS as a string

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -1105,7 +1105,7 @@ class Verilator(Simulator):
                 "-o",
                 self.toplevel_module,
                 "-LDFLAGS",
-                "-Wl,-rpath,{LIB_DIR} -L{LIB_DIR} -lcocotbvpi_verilator".format(LIB_DIR=self.lib_dir),
+                '"-Wl,-rpath,{LIB_DIR} -L{LIB_DIR} -lcocotbvpi_verilator"'.format(LIB_DIR=self.lib_dir),
             ]
             + compile_args
             + self.get_define_commands(self.defines)


### PR DESCRIPTION
Previously LDFLAGS are passed as a separate array of things, which may cause errors on certain versions of verilator

Signed-off-by: Tianrui Wei <tianrui@tianruiwei.com>