### PR TITLE
Depend on find_libpython as external package

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -9,7 +9,7 @@ from xml.etree import cElementTree as ET
 import threading
 import signal
 import warnings
-import cocotb._vendor.find_libpython as find_libpython
+import find_libpython
 import cocotb.config
 import asyncio
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     include_package_data = True,
     python_requires=">=3.7",
-    install_requires=["cocotb>=1.5", "pytest"],
+    install_requires=["cocotb>=1.5", "pytest", "find_libpython"],
     entry_points={
         "console_scripts": [
             "cocotb=cocotb_test.cli:config",


### PR DESCRIPTION
find_libpython was sourced from cocotb._vendor which is now removed in latest version. depends on external package in this commit.

Refer below for more info:
https://github.com/cocotb/cocotb/commit/ea08c7facad6fac606e23c4cf93d26f94572570e

https://github.com/cocotb/cocotb/issues/3131

https://github.com/cocotb/cocotb/issues/3133