### PR TITLE
add `timescale` arg to Simulator classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ cocotb-clean -r
 * `seed`: Seed the Python random module to recreate a previous test stimulus (see [RANDOM_SEED](https://docs.cocotb.org/en/stable/building.html?#envvar-RANDOM_SEED) ).
 * `extra_env`: A dictionary of extra environment variables set in simulator process.
 * `waves`: Enable wave dumps (not all simulators supported).
+* `timescale`: Set simulator time unit/precision (default: `1ns/1ps`)
 * `gui`: Starts in gui mode (not all simulators supported).
 
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cocotb-clean -r
 * `seed`: Seed the Python random module to recreate a previous test stimulus (see [RANDOM_SEED](https://docs.cocotb.org/en/stable/building.html?#envvar-RANDOM_SEED) ).
 * `extra_env`: A dictionary of extra environment variables set in simulator process.
 * `waves`: Enable wave dumps (not all simulators supported).
-* `timescale`: Set simulator time unit/precision (default: `1ns/1ps`)
+* `timescale`: Set simulator time unit/precision (default: `None`)
 * `gui`: Starts in gui mode (not all simulators supported).
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,7 @@ jobs:
           sudo apt-get install libfl2  # Ubuntu only (ignore if gives error)
           sudo apt-get install libfl-dev  # Ubuntu only (ignore if gives error)
           git clone http://git.veripool.org/git/verilator -b v4.106 --depth=1
+          cd verilator && git apply ../tests/verilator.include-limits.patch && cd ..
           cd verilator && autoconf && ./configure && make -j2 && sudo make install && cd ..
         displayName: Compile and Install Verilator on Linux
         condition: and( eq( variables['Agent.OS'], 'Linux' ), eq(variables['SIM'], 'verilator'))

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -57,6 +57,7 @@ class Simulator:
         extra_env=None,
         compile_only=False,
         waves=None,
+        timescale="1ns/1ps",
         gui=False,
         simulation_args=None,
         **kwargs,
@@ -178,6 +179,11 @@ class Simulator:
             self.waves = bool(int(os.getenv("WAVES", 0)))
         else:
             self.waves = bool(waves)
+
+        if timescale is None or re.fullmatch("\\d+[npu]s/\\d+[npu]s", timescale):
+            self.timescale = timescale
+        else:
+            raise ValueError("Invalid timescale: {}".format(timescale))
 
         self.gui = gui
 
@@ -493,6 +499,11 @@ class Icarus(Simulator):
             self.compile_args.extend(["-s", dump_mod_name])
             self.plus_args.append("-fst")
 
+        if self.timescale:
+            with open(self.sim_dir + "/timescale.f", "w") as f:
+                f.write("+timescale+{}\n".format(self.timescale))
+            self.compile_args.extend(["-f", self.sim_dir + "/timescale.f"])
+
         cmd = []
         if self.outdated(self.sim_file, verilog_sources) or self.force_compile:
             cmd.append(self.compile_command())
@@ -544,6 +555,8 @@ class Questa(Simulator):
 
         if self.verilog_sources:
             compile_args = self.compile_args + self.verilog_compile_args
+            if self.timescale:
+                compile_args += ["-timescale", self.timescale]
 
             for lib, src in self.verilog_sources.items():
                 cmd.append(["vlib", as_tcl_value(lib)])
@@ -742,6 +755,8 @@ class Xcelium(Simulator):
                 + self.verilog_sources_flat
                 + self.vhdl_sources_flat
             )
+            if self.timescale:
+                cmd_elab += ["-timescale", self.timescale]
 
             cmd.append(cmd_elab)
 
@@ -806,6 +821,9 @@ class Vcs(Simulator):
             + self.verilog_sources_flat
             + ["-o", simv_path]
         )
+        if self.timescale:
+            cmd += ["-timescale", self.timescale]
+
         cmd.append(cmd_build)
 
         if not self.compile_only:
@@ -1086,6 +1104,9 @@ class Verilator(Simulator):
 
         if self.waves:
             compile_args += ["--trace-fst", "--trace-structs"]
+
+        if self.timescale:
+            compile_args += ["--timescale", self.timescale]
 
         cmd.append(
             [

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -57,7 +57,7 @@ class Simulator:
         extra_env=None,
         compile_only=False,
         waves=None,
-        timescale="1ns/1ps",
+        timescale=None,
         gui=False,
         simulation_args=None,
         **kwargs,

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -500,9 +500,10 @@ class Icarus(Simulator):
             self.plus_args.append("-fst")
 
         if self.timescale:
-            with open(self.sim_dir + "/timescale.f", "w") as f:
+            timescale_cmd_file = os.path.join(self.sim_dir, "timescale.f")
+            with open(timescale_cmd_file, "w") as f:
                 f.write("+timescale+{}\n".format(self.timescale))
-            self.compile_args.extend(["-f", self.sim_dir + "/timescale.f"])
+            self.compile_args.extend(["-f", timescale_cmd_file])
 
         cmd = []
         if self.outdated(self.sim_file, verilog_sources) or self.force_compile:

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -180,7 +180,7 @@ class Simulator:
         else:
             self.waves = bool(waves)
 
-        if timescale is None or re.fullmatch("\\d+[npu]s/\\d+[npu]s", timescale):
+        if timescale is None or re.fullmatch("\\d+[npu]?s/\\d+[npu]?s", timescale):
             self.timescale = timescale
         else:
             raise ValueError("Invalid timescale: {}".format(timescale))

--- a/tests/test_multitop.py
+++ b/tests/test_multitop.py
@@ -17,7 +17,9 @@ def test_dff_verilog():
             os.path.join(tests_dir, "glbl_sink.v"),
         ],
         toplevel=["glbl_sink", "glbl"],
-        module="test_multitop"
+        module="test_multitop",
+        # time unit and precision set the same
+        timescale="1ns/1ns",
     )
 
 
@@ -26,6 +28,9 @@ async def glbl(dut):
     await ReadOnly()
     if dut.rst.value == 0:
         raise TestFailure()
+    # BEWARE: Timer(10) is equal to Timer(10, 'step') which is ten simulator *precision* steps.
+    # Only the same as Verilog delay '#10' (ten *time units*) when timescale directive sets
+    # the time unit same as precision ie. with timescale="1ns/1ns" or "1ps/1ps"
     await Timer(10)
     await ReadOnly()
     if dut.rst.value == 1:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -54,3 +54,26 @@ def test_dff_vhdl_testcase(parameters):
         sim_build="sim_build/"
         + "_".join(("{}={}".format(*i) for i in parameters.items())),
     )
+
+@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+def test_bad_timescales():
+
+    kwargs = {
+         'verilog_sources': [
+                os.path.join(tests_dir, "dff.sv"),
+            ],
+        'module': "dff_cocotb",
+        'toplevel': "dff_test",
+        'sim_build': "sim_build/test_missing_verilog",
+    }
+
+    with pytest.raises(ValueError, match='Invalid timescale: 1ns'):
+        run(timescale="1ns", **kwargs)
+
+    with pytest.raises(ValueError, match='Invalid timescale: 1qs/1s'):
+        run(timescale="1qs/1s", **kwargs)
+
+    run(timescale="100ns/100ns", **kwargs)
+    run(timescale="1ns/1ns", **kwargs)
+    run(timescale=None, **kwargs)
+

--- a/tests/verilator.include-limits.patch
+++ b/tests/verilator.include-limits.patch
@@ -1,0 +1,12 @@
+diff --git a/include/verilated.cpp b/include/verilated.cpp
+index 1010544..2b2fd3c 100644
+--- a/include/verilated.cpp
++++ b/include/verilated.cpp
+@@ -33,6 +33,7 @@
+ #include <sys/stat.h>  // mkdir
+ #include <list>
+ #include <utility>
++#include <limits>
+ 
+ // clang-format off
+ #if defined(_WIN32) || defined(__MINGW32__)


### PR DESCRIPTION
Simulators are relatively standardised in how they expect simulation time unit and precision to be passed, as a command line argument `-timescale unit/precision`. Icarus is different and needs a command file to avoid having to put the timescale identically in each Verilog compilation module. 

Cocotb abstracts this with Makefile variables `$(COCOTB_HDL_TIMEUNIT)/$(COCOTB_HDL_TIMEPRECISION)`, defaulted to 1ns/1ps, and passes to each simulator.

Support a similar abstraction in cocotb-test with `run(..., timescale="1ns/1ps")`, set as default. For environments where this has been handled already by explicit arguments, passing `timescale=None` will maintain existing behaviour.

I can add other simulators to this PR, but I don't have access to test, so would rather open follow-ups and let others sign off on them.

For a good primer in time unit / time precision interacting with Verilog #delays see https://www.chipverify.com/verilog/verilog-timescale