### PR TITLE
When using cocotb-run, set a timescale, if it's not set, and set color output

### DIFF
--- a/cocotb_test/cli.py
+++ b/cocotb_test/cli.py
@@ -97,6 +97,7 @@ def run():
         kwargs["compile_args"] = os.getenv("COMPILE_ARGS", "").split()
         kwargs["extra_args"] = os.getenv("EXTRA_ARGS", "").split()
         kwargs["plus_args"] = os.getenv("PLUS_ARGS", "").split()
+        kwargs["timescale"] = os.getenv("TIMESCALE", "1ns/1ps")
         kwargs["python_search"] = (
             os.getenv("PYTHONPATH", "").replace(";", " ").replace(":", " ").split()
         )

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -11,7 +11,6 @@ import signal
 import warnings
 import find_libpython
 import cocotb.config
-import cocotb.utils
 import asyncio
 import sysconfig
 
@@ -217,17 +216,6 @@ class Simulator:
 
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
-
-        # Use color output, if possible or requested. This is needed because
-        # cocotb is run in a subprocess with `stdout` and `stderr` attached to
-        # pipes. These pipes break cocotb's automatic color output as pipes
-        # return `False` for `isatty()`, causing color output to never be
-        # used, even when run in a terminal. `want_color_output()` checks
-        # *our* `stdout` for a terminal and enables or disables color in the
-        # subprocess, as appropriate, while still honoring any environment
-        # variable overrides, to preserve cocotb's color output behavior.
-        want_color = cocotb.utils.want_color_output()
-        self.env["COCOTB_ANSI_OUTPUT"] = "1" if want_color else "0"
 
         if not os.path.exists(self.sim_dir):
             os.makedirs(self.sim_dir)

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -217,7 +217,7 @@ class Simulator:
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
 
-        # Force color output, if stdout is a terminals
+        # Force color output, if stdout is a terminal
         if not os.getenv("COCOTB_ANSI_OUTPUT") and sys.stdout.isatty():
             self.env["COCOTB_ANSI_OUTPUT"] = "1"
 

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -217,9 +217,8 @@ class Simulator:
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
 
-        # Force color output, if stdout and stderr are terminals
-        output_isatty = sys.stdout.isatty() and sys.stderr.isatty()
-        if not os.getenv("COCOTB_ANSI_OUTPUT") and output_isatty:
+        # Force color output, if stdout is a terminal
+        if not os.getenv("COCOTB_ANSI_OUTPUT") and sys.stdout.isatty():
             self.env["COCOTB_ANSI_OUTPUT"] = "1"
 
         if not os.path.exists(self.sim_dir):

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -217,6 +217,11 @@ class Simulator:
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
 
+        # Force color output, if stdout and stderr are terminals
+        output_isatty = sys.stdout.isatty() and sys.stderr.isatty()
+        if not os.getenv("COCOTB_ANSI_OUTPUT") and output_isatty:
+            self.env["COCOTB_ANSI_OUTPUT"] = "1"
+
         if not os.path.exists(self.sim_dir):
             os.makedirs(self.sim_dir)
 

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -11,6 +11,7 @@ import signal
 import warnings
 import find_libpython
 import cocotb.config
+import cocotb.utils
 import asyncio
 import sysconfig
 
@@ -217,9 +218,9 @@ class Simulator:
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
 
-        # Force color output, if stdout is a terminal
-        if not os.getenv("COCOTB_ANSI_OUTPUT") and sys.stdout.isatty():
-            self.env["COCOTB_ANSI_OUTPUT"] = "1"
+        # Use color output, if possible or requested
+        want_color = cocotb.utils.want_color_output()
+        self.env["COCOTB_ANSI_OUTPUT"] = "1" if want_color else "0" 
 
         if not os.path.exists(self.sim_dir):
             os.makedirs(self.sim_dir)

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -218,9 +218,16 @@ class Simulator:
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
 
-        # Use color output, if possible or requested
+        # Use color output, if possible or requested. This is needed because
+        # cocotb is run in a subprocess with `stdout` and `stderr` attached to
+        # pipes. These pipes break cocotb's automatic color output as pipes
+        # return `False` for `isatty()`, causing color output to never be
+        # used, even when run in a terminal. `want_color_output()` checks
+        # *our* `stdout` for a terminal and enables or disables color in the
+        # subprocess, as appropriate, while still honoring any environment
+        # variable overrides, to preserve cocotb's color output behavior.
         want_color = cocotb.utils.want_color_output()
-        self.env["COCOTB_ANSI_OUTPUT"] = "1" if want_color else "0" 
+        self.env["COCOTB_ANSI_OUTPUT"] = "1" if want_color else "0"
 
         if not os.path.exists(self.sim_dir):
             os.makedirs(self.sim_dir)

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -217,7 +217,7 @@ class Simulator:
         self.env["TOPLEVEL"] = self.toplevel_module
         self.env["MODULE"] = self.module
 
-        # Force color output, if stdout is a terminal
+        # Force color output, if stdout is a terminals
         if not os.getenv("COCOTB_ANSI_OUTPUT") and sys.stdout.isatty():
             self.env["COCOTB_ANSI_OUTPUT"] = "1"
 


### PR DESCRIPTION
I have some `Makefile` based tests, and I noticed when switching from:

```
include $(shell cocotb-config --makefiles)/Makefile.sim
```

to:

```
include $(shell cocotb-test --inc-makefile)
```

there were two issues:

1. The timescale was not being set, causing simulation errors.
2. Cooctb output was no longer in color.

This PR sets the timescale to `1ns/1ps` by default and adds a `TIMESCALE` environment variable to override it. And also sets `COCOTB_ANSI_OUTPUT=1` if the output is a terminal.

## Details

For the timescale, I get these errors:

```
INFO cocotb:                                                             ValueError: Unable to accurately represent 1(ns) with the simulator precision of 1e0
```

This is because I do not have this in all my `.v` files:

```
`timescale 1ns/1ps
```

While I *could* update all my sources, this is not ideal. I believe Cocotb works without a `timescale` because of [`COCOTB_HDL_TIMEUNIT` ](https://docs.cocotb.org/en/stable/building.html?highlight=COCOTB_HDL_TIMEUNIT) and [`COCOTB_HDL_TIMEPRECISION `](https://docs.cocotb.org/en/stable/building.html#var-COCOTB_HDL_TIMEPRECISION). If not set, these default to `1ns` and `1ps`, respectively. 

The color is lost because `cocotb-test` runs `cocotb` via `asyncio.subprocess` with `stdout` and `stderr` as pipes. Because they are pipes, Cocotb turns off color. From the [`COCOTB_ANSI_OUTPUT `](https://docs.cocotb.org/en/stable/building.html#envvar-COCOTB_ANSI_OUTPUT) docs, the output is only color if the output is a terminal. This restores color output by checking if the output is a terminal, and then setting `COCOTB_ANSI_OUTPUT` appropriately.
