### PR TITLE
simulator: Add support for NVC

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,10 @@ jobs:
           python.version: "3.8"
           imageName: "ubuntu-latest"
           SIM: "ghdl"
+        Linux-NVC-py38:
+          python.version: "3.8"
+          imageName: "ubuntu-latest"
+          SIM: "nvc"
         Windows-Icarus-py310:
           python.version: "3.10"
           imageName: "windows-latest"
@@ -84,6 +88,14 @@ jobs:
           cd ghdl && ./configure && make -j2 && sudo make install && cd ..
         displayName: Compile and Install GHDL on Linux
         condition: and( eq( variables['Agent.OS'], 'Linux' ), eq(variables['SIM'], 'ghdl'))
+
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential automake autoconf flex check llvm-dev pkg-config zlib1g-dev libdw-dev libffi-dev libzstd-dev
+          git clone https://github.com/nickg/nvc.git --depth=1 --branch r1.10.4
+          cd nvc && ./autogen.sh && mkdir build && cd build && ../configure && make -j$(nproc) && sudo make install && cd ../..
+        displayName: Compile and Install NVC on Linux
+        condition: and( eq( variables['Agent.OS'], 'Linux' ), eq(variables['SIM'], 'nvc'))
 
       - script: |
           sudo apt-get update

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -28,6 +28,12 @@ def as_tcl_value(value):
 
     return value
 
+# Return `variable` if not None, else return `default`
+def some_or(variable, default):
+    if variable is None:
+        return default
+    else:
+        return variable
 
 class Simulator:
     def __init__(
@@ -85,84 +91,25 @@ class Simulator:
             if os.path.isdir(absworkdir):
                 self.work_dir = absworkdir
 
-        if python_search is None:
-            python_search = []
-
-        self.python_search = python_search
-
+        # Initialize from arguments
+        self.python_search = some_or(python_search, [])
         self.toplevel = toplevel
         self.toplevel_lang = toplevel_lang
 
-        if verilog_sources is None:
-            verilog_sources = []
-        self.verilog_sources = self.get_abs_paths(verilog_sources)
-
-        if vhdl_sources is None:
-            vhdl_sources = []
-        self.vhdl_sources = self.get_abs_paths(vhdl_sources)
-
-        if includes is None:
-            includes = []
-
-        self.includes = self.get_abs_paths(includes)
-
-        if defines is None:
-            defines = []
-
-        self.defines = defines
-
-        if parameters is None:
-            parameters = {}
-
-        self.parameters = parameters
-
-        if compile_args is None:
-            compile_args = []
-
-        if vhdl_compile_args is None:
-            self.vhdl_compile_args = []
-        else:
-            self.vhdl_compile_args = vhdl_compile_args
-
-        if verilog_compile_args is None:
-            self.verilog_compile_args = []
-        else:
-            self.verilog_compile_args = verilog_compile_args
-
-        if extra_args is None:
-            extra_args = []
-
-        self.compile_args = compile_args + extra_args
-
-        if sim_args is None:
-            sim_args = []
-
-        if simulation_args is not None:
-            sim_args += simulation_args
-            warnings.warn(
-                "Using simulation_args is deprecated. Please use sim_args instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        self.simulation_args = sim_args + extra_args
-
-        if plus_args is None:
-            plus_args = []
-
-        self.plus_args = plus_args
+        self.verilog_sources = self.get_abs_paths(some_or(verilog_sources, []))
+        self.vhdl_sources = self.get_abs_paths(some_or(vhdl_sources, []))
+        self.includes = self.get_abs_paths(some_or(includes, []))
+        self.defines = some_or(defines, [])
+        self.parameters = some_or(parameters, {})
+        self.compile_args = some_or(compile_args, [])
+        self.vhdl_compile_args = some_or(vhdl_compile_args, [])
+        self.verilog_compile_args = some_or(verilog_compile_args, [])
+        self.extra_args = some_or(extra_args, [])
+        self.simulation_args = some_or(sim_args, [])
+        self.plus_args = some_or(plus_args, [])
         self.force_compile = force_compile
         self.compile_only = compile_only
-
-        if kwargs:
-            warnings.warn(
-                "Using kwargs is deprecated. Please explicitly declare or arguments instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        for arg in kwargs:
-            setattr(self, arg, kwargs[arg])
+        self.waves = bool(some_or(waves, int(os.getenv("WAVES", 0))))
 
         # by copy since we modify
         self.env = dict(extra_env) if extra_env is not None else {}
@@ -173,15 +120,28 @@ class Simulator:
         if seed is not None:
             self.env["RANDOM_SEED"] = str(seed)
 
-        if waves is None:
-            self.waves = bool(int(os.getenv("WAVES", 0)))
-        else:
-            self.waves = bool(waves)
-
         if timescale is None or re.fullmatch("\\d+[npu]?s/\\d+[npu]?s", timescale):
             self.timescale = timescale
         else:
             raise ValueError("Invalid timescale: {}".format(timescale))
+
+        # Backwards compatibility
+        if simulation_args is not None:
+            self.simulation_args += simulation_args
+            warnings.warn(
+                "Using simulation_args is deprecated. Please use sim_args instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        if kwargs:
+            warnings.warn(
+                "Using kwargs is deprecated. Please explicitly declare or arguments instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            for arg in kwargs:
+                setattr(self, arg, kwargs[arg])
 
         self.gui = gui
 
@@ -457,7 +417,7 @@ class Icarus(Simulator):
 
     def compile_command(self):
 
-        compile_args = self.compile_args + self.verilog_compile_args
+        compile_args = self.compile_args + self.extra_args + self.verilog_compile_args
 
         toplevel = []
         for t in self.toplevel_module_list:
@@ -556,7 +516,7 @@ class Questa(Simulator):
         do_script = self.do_script()
 
         if self.vhdl_sources:
-            compile_args = self.compile_args + self.vhdl_compile_args
+            compile_args = self.compile_args + self.extra_args + self.vhdl_compile_args
 
             for lib, src in self.vhdl_sources.items():
                 cmd.append(["vlib", as_tcl_value(lib)])
@@ -568,7 +528,7 @@ class Questa(Simulator):
                 )
 
         if self.verilog_sources:
-            compile_args = self.compile_args + self.verilog_compile_args
+            compile_args = self.compile_args + self.extra_args + self.verilog_compile_args
             if self.timescale:
                 compile_args += ["-timescale", self.timescale]
 
@@ -690,7 +650,7 @@ class Ius(Simulator):
                 + self.get_define_commands(self.defines)
                 + self.get_include_commands(self.includes)
                 + self.get_parameter_commands(self.parameters)
-                + self.compile_args
+                + self.compile_args + self.extra_args
                 + self.verilog_sources_flat
                 + self.vhdl_sources_flat
             )
@@ -772,7 +732,7 @@ class Xcelium(Simulator):
                 + self.get_define_commands(self.defines)
                 + self.get_include_commands(self.includes)
                 + self.get_parameter_commands(self.parameters)
-                + self.compile_args
+                + self.compile_args + self.extra_args
                 + self.verilog_sources_flat
                 + self.vhdl_sources_flat
             )
@@ -816,7 +776,7 @@ class Vcs(Simulator):
         with open(do_file_path, "w") as pli_file:
             pli_file.write(pli_cmd)
 
-        compile_args = self.compile_args + self.verilog_compile_args
+        compile_args = self.compile_args + self.extra_args + self.verilog_compile_args
         debug_access = "-debug_access"
         if self.waves:
             debug_access += "+all+dmptf"
@@ -880,7 +840,7 @@ class Ghdl(Simulator):
         cmd = []
 
         out_file = os.path.join(self.sim_dir, self.toplevel_module)
-        compile_args = self.compile_args + self.vhdl_compile_args
+        compile_args = self.compile_args + self.extra_args + self.vhdl_compile_args
 
         if self.outdated(out_file, self.vhdl_sources) or self.force_compile:
             for lib, src in self.vhdl_sources.items():
@@ -925,12 +885,12 @@ class Nvc(Simulator):
         cmd = []
 
         out_file = os.path.join(self.sim_dir, self.toplevel_module)
-
+        compile_args = self.compile_args + self.vhdl_compile_args
         if self.outdated(out_file, self.vhdl_sources) or self.force_compile:
             for lib, src in self.vhdl_sources.items():
-                cmd.append(["nvc"] + self.compile_args + [f"--work={lib}", "-L", self.sim_dir, "-a"] + self.vhdl_compile_args + src)
+                cmd.append(["nvc"] + self.extra_args + [f"--work={lib}", "-L", self.sim_dir, "-a"] + compile_args + src)
 
-            cmd_elaborate = ["nvc"] + self.compile_args + [f"--work={self.toplevel_library}", "-L", self.sim_dir, "-e"] + self.vhdl_compile_args + self.get_parameter_commands(self.parameters) + [self.toplevel_module]
+            cmd_elaborate = ["nvc"] + self.extra_args + [f"--work={self.toplevel_library}", "-L", self.sim_dir, "-e"] + compile_args + self.get_parameter_commands(self.parameters) + [self.toplevel_module]
             cmd.append(cmd_elaborate)
 
         if self.waves:
@@ -940,7 +900,7 @@ class Nvc(Simulator):
 
         cmd_run = (
             ["nvc", f"--work={self.toplevel_library}"]
-            + self.compile_args
+            + self.extra_args
             + ["-L", self.sim_dir, "--stderr=error"]
             + ["-r"]
             + [self.toplevel_module]
@@ -977,7 +937,7 @@ class Riviera(Simulator):
             do_script += f"alib {as_tcl_value(self.rtl_library)} \n"
 
             if self.vhdl_sources:
-                compile_args = self.compile_args + self.vhdl_compile_args
+                compile_args = self.compile_args + self.extra_args + self.vhdl_compile_args
                 do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
                     RTL_LIBRARY=as_tcl_value(self.rtl_library),
                     VHDL_SOURCES=" ".join(as_tcl_value(v) for v in self.vhdl_sources_flat),
@@ -985,7 +945,7 @@ class Riviera(Simulator):
                 )
 
             if self.verilog_sources:
-                compile_args = self.compile_args + self.verilog_compile_args
+                compile_args = self.compile_args + self.extra_args + self.verilog_compile_args
                 do_script += "alog -work {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
                     RTL_LIBRARY=as_tcl_value(self.rtl_library),
                     VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in self.verilog_sources_flat),
@@ -1055,7 +1015,7 @@ class Activehdl(Simulator):
             do_script += f"alib {as_tcl_value(self.rtl_library)} \n"
 
             if self.vhdl_sources:
-                compile_args = self.compile_args + self.vhdl_compile_args
+                compile_args = self.compile_args + self.extra_args + self.vhdl_compile_args
                 do_script += "acom -work {RTL_LIBRARY} {EXTRA_ARGS} {VHDL_SOURCES}\n".format(
                     RTL_LIBRARY=as_tcl_value(self.rtl_library),
                     VHDL_SOURCES=" ".join(as_tcl_value(v) for v in self.vhdl_sources_flat),
@@ -1063,7 +1023,7 @@ class Activehdl(Simulator):
                 )
 
             if self.verilog_sources:
-                compile_args = self.compile_args + self.verilog_compile_args
+                compile_args = self.compile_args + self.extra_args + self.verilog_compile_args
                 do_script += "alog {RTL_LIBRARY} +define+COCOTB_SIM -sv {DEFINES} {INCDIR} {EXTRA_ARGS} {VERILOG_SOURCES} \n".format(
                     RTL_LIBRARY=as_tcl_value(self.rtl_library),
                     VERILOG_SOURCES=" ".join(as_tcl_value(v) for v in self.verilog_sources_flat),
@@ -1172,7 +1132,7 @@ class Verilator(Simulator):
         if verilator_exec is None:
             raise ValueError("Verilator executable not found.")
 
-        compile_args = self.compile_args + self.verilog_compile_args
+        compile_args = self.compile_args + self.extra_args + self.verilog_compile_args
 
         if self.waves:
             compile_args += ["--trace-fst", "--trace-structs"]

--- a/tests/subfolder1/subfolder2/test_work_dir.py
+++ b/tests/subfolder1/subfolder2/test_work_dir.py
@@ -4,12 +4,12 @@ import os
 
 dir = os.path.dirname(__file__)
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.xfail(reason="Expected to fail with no work_dir specified")
 def test_dff_no_workdir():
     run(verilog_sources=[os.path.join(dir, "..", "..", "dff.sv")], toplevel="dff_test", module="dff_cocotb")  # sources  # top level HDL  # name of cocotb test module
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 def test_dff_workdir():
     run(verilog_sources=[os.path.join(dir, "..", "..", "dff.sv")], work_dir=os.path.join(dir, "..", ".."), toplevel="dff_test", module="dff_cocotb")  # sources  # top level HDL  # name of cocotb test module
 

--- a/tests/test_cocotb_examples.py
+++ b/tests/test_cocotb_examples.py
@@ -10,7 +10,7 @@ if os.path.isdir(example_dir) == False:
     raise IOError("Cocotb example directory not found. Please clone with git and install with `pip -e`")
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 def test_adder_verilog():
     run(
         verilog_sources=[os.path.join(example_dir, "adder", "hdl", "adder.sv")],
@@ -21,7 +21,7 @@ def test_adder_verilog():
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Errors in compilation cocotb example")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Errors in compilation cocotb example")
 @pytest.mark.skipif(os.getenv("SIM") in ["icarus", "verilator"], reason="VHDL not supported")
 def test_adder_vhdl():
     run(

--- a/tests/test_cocotb_tests.py
+++ b/tests/test_cocotb_tests.py
@@ -13,7 +13,7 @@ if os.path.isdir(tests_dir) == False:
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.skipif(os.getenv("SIM") in ["icarus", "verilator"] , reason="VHDL not supported")
 def test_verilog_access():
     run(

--- a/tests/test_compile_errors.py
+++ b/tests/test_compile_errors.py
@@ -23,7 +23,7 @@ def test_invalid_vhdl():
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.xfail(strict=True, raises=SystemExit)
 def test_invalid_verilog():
     run(
@@ -53,7 +53,7 @@ def test_missing_vhdl():
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.skipif(os.getenv("SIM") == "icarus", reason="Missing source is not an error in Icarus?")
 @pytest.mark.xfail(strict=True)
 def test_missing_verilog():

--- a/tests/test_dff.py
+++ b/tests/test_dff.py
@@ -5,7 +5,7 @@ import os
 tests_dir = os.path.dirname(__file__)
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 # @pytest.mark.parametrize("seed", range(10))
 def test_dff_verilog():
     run(verilog_sources=[os.path.join(tests_dir, "dff.sv")], toplevel="dff_test", module="dff_cocotb", waves=True)  # sources  # top level HDL  # name of cocotb test module

--- a/tests/test_long_log.py
+++ b/tests/test_long_log.py
@@ -18,6 +18,6 @@ def run_test_long_log(dut):
     dut._log.info("AFTER")
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="VHDL not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="VHDL not suported")
 def test_long_log():
     run(verilog_sources=[os.path.join(hdl_dir, "dff.sv")], module="test_long_log", toplevel="dff_test")

--- a/tests/test_named_lib.py
+++ b/tests/test_named_lib.py
@@ -4,7 +4,7 @@ import os
 
 tests_dir = os.path.dirname(__file__)
 
-@pytest.mark.skipif(os.getenv("SIM") not in ("questa", "ghdl"), reason="Named libraries only supported for Questa, GHDL.")
+@pytest.mark.skipif(os.getenv("SIM") not in ("questa", "ghdl", "nvc"), reason="Named libraries only supported for Questa, GHDL, and NVC.")
 def test_dff_vhdl():
     run(
         vhdl_sources = {

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -11,7 +11,7 @@ tests_dir = os.path.dirname(__file__)
 # pytest -m 'not compile' -n 2 test_parallel.py
 # There are possibly better ways to do this
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.compile
 def test_complile():
     run(
@@ -22,7 +22,7 @@ def test_complile():
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.parametrize("seed", range(6))
 def test_dff_verilog_param(seed):
     run(
@@ -33,7 +33,7 @@ def test_dff_verilog_param(seed):
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.parametrize("seed", range(2))
 def test_dff_verilog_testcase(seed):
     run(

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -20,7 +20,7 @@ def run_test_paramters(dut):
     assert WIDTH_OUT == len(dut.data_out)
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.parametrize(
     "parameters", [{"WIDTH_IN": "8", "WIDTH_OUT": "16"}, {"WIDTH_IN": "16"}]
 )
@@ -55,7 +55,7 @@ def test_dff_vhdl_testcase(parameters):
         + "_".join(("{}={}".format(*i) for i in parameters.items())),
     )
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 def test_bad_timescales():
 
     kwargs = {

--- a/tests/test_plus_args.py
+++ b/tests/test_plus_args.py
@@ -17,7 +17,7 @@ def run_test(dut):
     assert user_mode == 1, "user_mode mismatch detected : got %d, exp %d!" % (dut.user_mode, 1)
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 def test_plus_args():
     run(
         verilog_sources=[os.path.join(hdl_dir, "plus_args.sv")],
@@ -27,13 +27,13 @@ def test_plus_args():
     )
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.xfail
 def test_plus_args_fail():
     run(verilog_sources=[os.path.join(hdl_dir,"plus_args.sv")], toplevel="plus_args")
 
 
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.xfail
 def test_plus_args_test_wrong():
     run(

--- a/tests/test_simulator_kwarg.py
+++ b/tests/test_simulator_kwarg.py
@@ -9,7 +9,7 @@ tests_dir = os.path.dirname(__file__)
 
 
 # Check that SIM= environment variable takes priority over kwarg
-@pytest.mark.skipif(os.getenv("SIM") == "ghdl", reason="Verilog not suported")
+@pytest.mark.skipif(os.getenv("SIM") in ("ghdl", "nvc"), reason="Verilog not suported")
 @pytest.mark.xfail(os.getenv("SIM") is None,
                    reason="Bad simulator name should be used when SIM is unset",
                    strict=True,


### PR DESCRIPTION
This PR adds support for the [NVC](https://github.com/nickg/nvc) VHDL simulator.

This PR is a ready for review:

* [x] Add NVC as a simulator
* [x] Integrate NVC into CI tests
* [x] Check that all error messages printed are not something to be fixed in cocotb-test
* [x] Figure out how to handle pre-command compile options vs post-command compile options
* [x] Wait until NVC support has been added upstream in cocotb, tracked as https://github.com/cocotb/cocotb/pull/3427