### PR TITLE
Change fork to start_soon

### DIFF
--- a/tests/dff_cocotb.py
+++ b/tests/dff_cocotb.py
@@ -12,7 +12,7 @@ async def test_dff_simple(dut):
     """ Test that d propagates to q """
 
     clock = Clock(dut.clk, 10, units="us")  # Create a 10us period clock on port clk
-    cocotb.fork(clock.start())  # Start the clock
+    cocotb.start_soon(clock.start())  # Start the clock
 
     await FallingEdge(dut.clk)  # Synchronize with the clock
     for i in range(10):


### PR DESCRIPTION
Hey, I revised the dff_cocotb.py so that the example in README can run without warning about "fork deprecated".