### PR TITLE
simulator: Remove -mixedsvvh from default args for Questa

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -520,7 +520,7 @@ class Questa(Simulator):
             for lib, src in self.vhdl_sources.items():
                 cmd.append(["vlib", as_tcl_value(lib)])
                 cmd.append(
-                    ["vcom", "-mixedsvvh"]
+                    ["vcom"]
                     + ["-work", as_tcl_value(lib)]
                     + compile_args
                     + [as_tcl_value(v) for v in src]
@@ -534,7 +534,7 @@ class Questa(Simulator):
             for lib, src in self.verilog_sources.items():
                 cmd.append(["vlib", as_tcl_value(lib)])
                 cmd.append(
-                    ["vlog", "-mixedsvvh"]
+                    ["vlog"]
                     + ([] if self.force_compile else ["-incr"])
                     + ["-work", as_tcl_value(lib)]
                     + ["+define+COCOTB_SIM"]


### PR DESCRIPTION
This argument should only be applied if the user requires it, which can be done by using the compile flags configuration parameter.

Having it always applied is causing problems for us in our current project as it triggers a bug in Questa (`internal error: ../../src/vcom/vh_convpack.c(5267). Please contact Questa support`)

CC @gts-bzi