### PR TITLE
CI: Switch to verilator repo on github

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get install libfl2
           sudo apt-get install libfl-dev
           sudo apt-get install help2man
-          git clone http://git.veripool.org/git/verilator --depth=1
+          git clone https://github.com/verilator/verilator --depth=1
           cd verilator && autoconf && ./configure && make -j2 && sudo make install && cd ..
         displayName: Compile and Install Verilator on Linux
         condition: and( eq( variables['Agent.OS'], 'Linux' ), eq(variables['SIM'], 'verilator'))


### PR DESCRIPTION
http://git.veripool.org/git/verilator is 404 as of 2025-01-03.