### PR TITLE
Disable mac in CI  

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,11 +48,11 @@ jobs:
           imageName: "windows-latest"
           SIM: "icarus"
           cocotb_version: "v1.9.0"
-        Mac-Icarus-py38:
-          imageName: "macOS-latest"
-          python.version: "3.8"
-          SIM: "icarus"
-          cocotb_version: "v1.9.0"
+        # Mac-Icarus-py38:
+        #   imageName: "macOS-latest"
+        #   python.version: "3.8"
+        #   SIM: "icarus"
+        #   cocotb_version: "v1.9.0"
         Linux-Verilator-py38:
           python.version: "3.8"
           imageName: "ubuntu-latest"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,19 +77,20 @@ jobs:
       - powershell: |
           Invoke-WebRequest -outfile miniconda3.exe https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe
           Start-Process .\miniconda3.exe -ArgumentList '/S /D=C:\miniconda3' -Wait
+          Write-Host "##vso[task.setvariable variable=CONDA;]C:\miniconda3"
           Write-Host "##vso[task.prependpath]C:\miniconda3;C:\miniconda3\Library\mingw-w64\bin;C:\miniconda3\Library\usr\bin;C:\miniconda3\Library\bin;C:\miniconda3\Scripts;C:\miniconda3\bin;C:\miniconda3\condabin"
         displayName: Download and Install Anaconda on Windows
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
 
-      - script: echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: Add conda to PATH
-        condition: ne( variables['Agent.OS'], 'Windows_NT' )
-
       - script: |
-          sudo chown -R $USER $CONDA
-          gcc --version
-        displayName: Take ownership of conda installation
+          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
+          bash ~/miniconda.sh -b -p $HOME/miniconda
+          echo "##vso[task.setvariable variable=CONDA;]$HOME/miniconda"
+        displayName: Download and Install Anaconda on Darwin
         condition: eq( variables['Agent.OS'], 'Darwin' )
+
+      - bash: echo "##vso[task.prependpath]$CONDA/bin"
+        displayName: Add conda to PATH
 
       - script: conda init
         displayName: Init Conda


### PR DESCRIPTION
Fixed conda but now getting error when building cocotb:
```
ld: unsupported mach-o filetype (only MH_OBJECT and MH_DYLIB can be linked) in '/private/var/folders/46/4tfh0cn14fn7tm2ghxwg5vtm0000gn/T/tmpqvq256j1.build-lib/cocotb/libs/libgpilog.so'
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
https://dev.azure.com/themperek/themperek/_build/results?buildId=948&view=logs&j=b6664ab9-9e4f-55af-562b-1e9b624dd54f&t=48f1ee46-e476-521a-83e7-70bc58df67d3&l=89

🤷🏻‍♂️ 
