### PR TITLE
Remove deprecated pkg_resources import from cli.py

### DIFF
--- a/cocotb_test/cli.py
+++ b/cocotb_test/cli.py
@@ -31,8 +31,7 @@
 import os
 import sys
 import argparse
-import pkg_resources
-from cocotb_test import simulator
+from cocotb_test import simulator, __version__
 
 
 class PrintAction(argparse.Action):
@@ -48,7 +47,7 @@ class PrintAction(argparse.Action):
 def config():
 
     makefiles_dir = os.path.join(os.path.dirname(__file__), "Makefile.inc")
-    version = pkg_resources.get_distribution("cocotb-test").version
+    version = __version__
 
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(


### PR DESCRIPTION
`pkg_resources` has been deprecated, causing CLI commands `cocotb-run, cocotb-clean` to break on newer python versions. I noticed that it was only used to report `cocotb-test`'s version, so I just read this value from `cocotb_test.__version__` instead.