### PR TITLE
2.x compatibility improvement

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -115,7 +115,7 @@ class Simulator:
         self.env = dict(extra_env) if extra_env is not None else {}
 
         if testcase is not None:
-            self.env["COCOTB_TESTCASE" if cocotb_2x_or_newer else "TESTCASE"] = self.toplevel_module
+            self.env["COCOTB_TESTCASE" if cocotb_2x_or_newer else "TESTCASE"] = testcase
 
         if seed is not None:
             self.env["COCOTB_RANDOM_SEED" if cocotb_2x_or_newer else "RANDOM_SEED"] = str(seed)

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -115,7 +115,7 @@ class Simulator:
         self.env = dict(extra_env) if extra_env is not None else {}
 
         if testcase is not None:
-            self.env["COCOTB_TESTCASE" if cocotb_2x_or_newer else "TESTCASE"] = testcase
+            self.env["COCOTB_TEST_FILTER" if cocotb_2x_or_newer else "TESTCASE"] = testcase
 
         if seed is not None:
             self.env["COCOTB_RANDOM_SEED" if cocotb_2x_or_newer else "RANDOM_SEED"] = str(seed)

--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -115,7 +115,7 @@ class Simulator:
         self.env = dict(extra_env) if extra_env is not None else {}
 
         if testcase is not None:
-            self.env["TESTCASE"] = testcase
+            self.env["COCOTB_TESTCASE" if cocotb_2x_or_newer else "TESTCASE"] = self.toplevel_module
 
         if seed is not None:
             self.env["COCOTB_RANDOM_SEED" if cocotb_2x_or_newer else "RANDOM_SEED"] = str(seed)


### PR DESCRIPTION
Using COCOTB_TEST_FILTER instead of TESTCASE for cocotb 2.x compatibility. Fix for #278