### PR TITLE
cast any value given to as_tcl_value as str

### DIFF
--- a/cocotb_test/simulator.py
+++ b/cocotb_test/simulator.py
@@ -20,7 +20,7 @@ _space_re = re.compile(r"([\s])", re.ASCII)
 
 def as_tcl_value(value):
     # add '\' before special characters and spaces
-    value = _magic_re.sub(r"\\\1", value)
+    value = _magic_re.sub(r"\\\1", str(value))
     value = value.replace("\n", r"\n")
     value = _space_re.sub(r"\\\1", value)
     if value[0] == '"':


### PR DESCRIPTION
This is done due to issue #281 and the fact that the file path for the VPI library returned by cocotb is a class PosixPath and not a string.